### PR TITLE
Open-Source platforms linking fixation (Community Page)

### DIFF
--- a/community.html
+++ b/community.html
@@ -36,19 +36,19 @@
                     <i class="fab fa-github"></i>
                     <h3>GitHub</h3>
                     <p>The world's largest platform for open source development, hosting millions of repositories and developers.</p>
-                    <a href="https://github.com" class="platform-link">Visit GitHub</a>
+                    <a href="https://github.com" target="_blank" rel="noopener noreferrer" class="platform-link">Visit GitHub</a>
                 </div>
                 <div class="platform-card">
                     <i class="fab fa-gitlab"></i>
                     <h3>GitLab</h3>
                     <p>A complete DevOps platform that enables teams to collaborate and build better software.</p>
-                    <a href="https://gitlab.com" class="platform-link">Visit GitLab</a>
+                    <a href="https://gitlab.com" target="_blank" rel="noopener noreferrer" class="platform-link">Visit GitLab</a>
                 </div>
                 <div class="platform-card">
                     <i class="fab fa-bitbucket"></i>
                     <h3>Bitbucket</h3>
                     <p>A Git-based source code repository hosting service owned by Atlassian.</p>
-                    <a href="https://bitbucket.org" class="platform-link">Visit Bitbucket</a>
+                    <a href="https://bitbucket.org" target="_blank" rel="noopener noreferrer" class="platform-link">Visit Bitbucket</a>
                 </div>
             </div>
         </section>

--- a/community.html
+++ b/community.html
@@ -36,19 +36,19 @@
                     <i class="fab fa-github"></i>
                     <h3>GitHub</h3>
                     <p>The world's largest platform for open source development, hosting millions of repositories and developers.</p>
-                    <a href="#" class="platform-link">Visit GitHub</a>
+                    <a href="https://github.com" class="platform-link">Visit GitHub</a>
                 </div>
                 <div class="platform-card">
                     <i class="fab fa-gitlab"></i>
                     <h3>GitLab</h3>
                     <p>A complete DevOps platform that enables teams to collaborate and build better software.</p>
-                    <a href="#" class="platform-link">Visit GitLab</a>
+                    <a href="https://gitlab.com" class="platform-link">Visit GitLab</a>
                 </div>
                 <div class="platform-card">
                     <i class="fab fa-bitbucket"></i>
                     <h3>Bitbucket</h3>
                     <p>A Git-based source code repository hosting service owned by Atlassian.</p>
-                    <a href="#" class="platform-link">Visit Bitbucket</a>
+                    <a href="https://bitbucket.org" class="platform-link">Visit Bitbucket</a>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -96,9 +96,9 @@
             <div class="footer-section">
                 <h3>Connect With Us</h3>
                 <div class="social-links">
-                    <a href="#"><i class="fab fa-github"></i></a>
-                    <a href="#"><i class="fab fa-twitter"></i></a>
-                    <a href="#"><i class="fab fa-linkedin"></i></a>
+                    <a href="https://github.com/ElixirTechCommunity"><i class="fab fa-github"></i></a>
+                    <a href="https://x.com/TheElixirTech"><i class="fab fa-twitter"></i></a>
+                    <a href="https://www.linkedin.com/company/geeksforgeeks-abesec"><i class="fab fa-linkedin"></i></a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
On the **community page**, I fixed the linking of _Open Source platforms_, which was expected to open in a new page, as shown in the directed issue.

"Add links to the Popular Open Source Platform #2"

Following is the image of change that I have fixed---
"https://github.com/user-attachments/assets/40b54cd2-f5aa-4d81-b1f3-d484eca5b4f6"
